### PR TITLE
Fix dummy search cleanup

### DIFF
--- a/composables/useDummySearch.ts
+++ b/composables/useDummySearch.ts
@@ -1,4 +1,5 @@
 import type { DisplaySearchResult } from '~/types/search'
+import { onWatcherCleanup } from 'vue'
 
 const mockResults: DisplaySearchResult[] = [
   {
@@ -51,9 +52,10 @@ export const useDummySearch = (searchQuery: Ref<string>) => {
   watch(searchQuery, (newQuery) => {
     if (newQuery) {
       isLoading.value = true
-      setTimeout(() => {
+      const id = setTimeout(() => {
         isLoading.value = false
       }, 500)
+      onWatcherCleanup(() => clearTimeout(id))
     }
   })
 


### PR DESCRIPTION
## Summary
- ensure dummy search clears prior timeout with onWatcherCleanup

## Testing
- `npm run typecheck` *(fails: `nuxt` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400f3476e08324b9e4dee1644964ad