### PR TITLE
Add AGENTS instructions and refine Cursor rules

### DIFF
--- a/.cursor/rules/auto-import.mdc
+++ b/.cursor/rules/auto-import.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description: Nuxt auto-import guidelines for composables and components
 globs: *.vue,*.ts
 alwaysApply: false
 ---
@@ -18,18 +18,19 @@ alwaysApply: false
 
 ## Directory-based Auto-imports
 - All functions from composables/ directory are auto-imported
-- All components from components/ directory are auto-imported  
+- All components from components/ directory are auto-imported
 - All utilities from utils/ directory are auto-imported
 - All functions from server/utils/ are auto-imported in server context
+
 ## Key Rules
 - Never suggest importing Vue APIs like ref, computed, watch - they are auto-imported
-- Never suggest importing Nuxt composables like useFetch, useRoute - they are auto-imported
+- Never suggest importing Nuxt composables like useFetch or useRoute - they are auto-imported
 - Never suggest importing from composables/, utils/, or components/ - they are auto-imported
-- If explicit import is needed, use #imports alias: `import { ref } from '#imports'`
+- If explicit import is needed, use the `#imports` alias: `import { ref } from '#imports'`
 - Components in templates don't need imports - they are auto-discovered
 - Server utilities in server/ directory are automatically available
 
 ## Exception Cases
 - Third-party package functions need explicit imports unless configured in [nuxt.config.ts](mdc:nuxt.config.ts)
 - If auto-import is disabled in [nuxt.config.ts](mdc:nuxt.config.ts), then explicit imports are required
-- Use explicit imports from #imports only when auto-import behavior needs to be overridden
+- Use explicit imports from `#imports` only when auto-import behavior needs to be overridden

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,9 +1,9 @@
 ---
-description: 
-globs: 
+description: General coding guidelines
+globs:
+  - '**/*'
 alwaysApply: true
 ---
-- never add comments try to make everything redable with variable names or code only
-
-- prefer functional core imperative shell pattern
-- try to never use any in typescript
+- Avoid code comments; rely on clear variable and function names for readability.
+- Prefer the functional-core, imperative-shell pattern.
+- Avoid using the `any` type in TypeScript.

--- a/.cursor/rules/nuxt-content.mdc
+++ b/.cursor/rules/nuxt-content.mdc
@@ -1,6 +1,6 @@
 ---
 description: Questions about Nuxt Content
-globs: 
+globs: '**/*'
 alwaysApply: false
 ---
 # Nuxt Content General Help & Documentation Rule

--- a/.cursor/rules/vue.mdc
+++ b/.cursor/rules/vue.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description: Vue 3.5 coding guidelines for .vue files
 globs: *.vue
 alwaysApply: false
 ---
@@ -7,18 +7,17 @@ alwaysApply: false
 
 ## General
 
-- script part always first then template
-- never define emits or props type outside directly use them in 
-defineProps or defineEmits
+- Place the `<script setup>` block before the template.
+- Define props and emits directly inside `defineProps` and `defineEmits`.
 
 always define them like
 
 ```vue
-const { 
-  modelValue, 
-  placeholder = 'Search...', 
+const {
+  modelValue,
+  placeholder = 'Search...',
   disabled = false,
-  autofocus = false 
+  autofocus = false
 } = defineProps<{
   modelValue: string
   placeholder?: string
@@ -26,6 +25,7 @@ const {
   autofocus?: boolean
 }>()
 ```
+
 
 ## VueUse First Approach
 - **ALWAYS** search the web first to check if VueUse has a composable that can solve the problem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Instructions
+
+This project uses Nuxt 3 with Nuxt Content. Follow these guidelines when modifying the repository.
+
+## Setup
+- Install dependencies with `npm install`.
+- Start the dev server via `npm run dev`.
+- Run `npm run typecheck` to perform TypeScript checks.
+
+## Coding Style
+- Obey the rules in `.cursor/rules/`.
+- Avoid code comments; use descriptive names instead.
+- Prefer the functional-core, imperative-shell pattern.
+- Do not use the `any` type in TypeScript.
+- For Vue files, place the `<script setup>` block before the template and define props/events with `defineProps`/`defineEmits` directly.
+- Nuxt composables and components are auto-imported; avoid explicit imports unless necessary.
+
+## Contributing
+- Commit messages should be clear and concise.
+- Run `npm run typecheck` before committing. If it fails because dependencies are missing, mention this in your PR description.
+
+## Cursor Rule Improvements
+- Rule files in `.cursor/rules/` now include descriptions and corrected language.


### PR DESCRIPTION
## Summary
- document project guidelines in `AGENTS.md`
- add descriptions to Cursor rule files and tweak language

## Testing
- `npm run typecheck` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400e3e24708324a83db4ac092a4b00