### PR TITLE
Refactor logicAnd generic

### DIFF
--- a/composables/logicAnd.ts
+++ b/composables/logicAnd.ts
@@ -6,8 +6,8 @@ import { computed, toValue } from 'vue'
  *
  * @see https://vueuse.org/logicAnd
  */
-export function logicAnd(...args: MaybeRefOrGetter<any>[]): ComputedRef<boolean> {
-  return computed(() => args.every(i => toValue(i)))
+export function logicAnd<T>(...args: MaybeRefOrGetter<T>[]): ComputedRef<boolean> {
+  return computed(() => args.every(i => Boolean(toValue(i))))
 }
 
 // alias


### PR DESCRIPTION
## Summary
- use a generic parameter in `logicAnd`

## Testing
- `npm run typecheck` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402231e0588324b51bacb2233382fc