### PR TITLE
Remove body from semantic search query

### DIFF
--- a/composables/useSemanticSearch.ts
+++ b/composables/useSemanticSearch.ts
@@ -29,7 +29,7 @@ export const useSemanticSearch = (searchQuery: Ref<string>) => {
 
   const { data: allPosts } = useAsyncData('all-posts-for-semantic-search', () => 
     queryCollection('blog')
-      .select('title', 'description', 'path', 'date', 'tags', 'body', 'embedding')
+      .select('title', 'description', 'path', 'date', 'tags', 'embedding')
       .all()
   )
 


### PR DESCRIPTION
## Summary
- avoid loading post bodies in semantic search composable

## Testing
- `npm run typecheck` *(fails: `nuxt` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840222e6a2c832492f664594b05016b